### PR TITLE
Fix typo in GenerateProjectFailedError message.

### DIFF
--- a/samcli/local/init/exceptions.py
+++ b/samcli/local/init/exceptions.py
@@ -14,4 +14,4 @@ class InitErrorException(Exception):
 
 class GenerateProjectFailedError(InitErrorException):
     fmt = \
-        ("An error ocurred while generating this {project}: {provider_error}")
+        ("An error occurred while generating this {project}: {provider_error}")

--- a/samcli/local/init/exceptions.py
+++ b/samcli/local/init/exceptions.py
@@ -2,7 +2,7 @@
 Custom Exceptions for Init module
 """
 
-# test2
+# test3
 
 class InitErrorException(Exception):
     fmt = 'An unspecified error occurred'

--- a/samcli/local/init/exceptions.py
+++ b/samcli/local/init/exceptions.py
@@ -2,6 +2,7 @@
 Custom Exceptions for Init module
 """
 
+# test2
 
 class InitErrorException(Exception):
     fmt = 'An unspecified error occurred'

--- a/samcli/local/init/exceptions.py
+++ b/samcli/local/init/exceptions.py
@@ -2,7 +2,7 @@
 Custom Exceptions for Init module
 """
 
-# test3
+# test4
 
 class InitErrorException(Exception):
     fmt = 'An unspecified error occurred'


### PR DESCRIPTION
Fix typo ocurred -> occurred.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
